### PR TITLE
[52] canvas fixes

### DIFF
--- a/packages/client/src/components/pages/game/scripts/canvas/index.ts
+++ b/packages/client/src/components/pages/game/scripts/canvas/index.ts
@@ -36,7 +36,7 @@ class Canvas {
      */
     this._offscreenCanvas = window.OffscreenCanvas
       ? new OffscreenCanvas(this.width, this.height) as OffscreenCanvas
-      : document.querySelector(selector) as HTMLCanvasElement
+      : document.createElement('canvas') as HTMLCanvasElement
 
     this._offscreenCanvas.width = this.width
     this._offscreenCanvas.height = this.height

--- a/packages/client/src/components/pages/game/scripts/canvas/index.ts
+++ b/packages/client/src/components/pages/game/scripts/canvas/index.ts
@@ -15,8 +15,8 @@ import { getImageCoords, sprite } from '../images'
 class Canvas {
   private _canvas: HTMLCanvasElement
   private _context: CanvasRenderingContext2D
-  private _offscreenCanvas: OffscreenCanvas
-  private _offscreenContext: OffscreenCanvasRenderingContext2D
+  private _offscreenCanvas: HTMLCanvasElement | OffscreenCanvas
+  private _offscreenContext: CanvasRenderingContext2D | OffscreenCanvasRenderingContext2D
 
   // Альфа-канал не нужен для статического канваса, экономим ресурсы
   constructor(selector: canvasSelectors, alpha = false) {
@@ -31,12 +31,16 @@ class Canvas {
 
     /**
      * Используем offscreenCanvas, чтобы рисовать объекты вне DOM и потом рендерить в один заход
-     * Фича не кроссбраузерная, можно добавить полифил, на крайняк вернемся к обычному контексту
+     * Поддерживается не везде, поэтому используем фолбэк в виде обычного канваса вне DOM
+     * При этом игра не настолько блокирует основной поток, чтобы задействовать воркер
      */
-    this._offscreenCanvas = new OffscreenCanvas(this.width, this.height)
+    this._offscreenCanvas = window.OffscreenCanvas
+      ? new OffscreenCanvas(this.width, this.height) as OffscreenCanvas
+      : document.querySelector(selector) as HTMLCanvasElement
+
     this._offscreenCanvas.width = this.width
     this._offscreenCanvas.height = this.height
-    this._offscreenContext = this._offscreenCanvas.getContext('2d') as OffscreenCanvasRenderingContext2D
+    this._offscreenContext = this._offscreenCanvas.getContext('2d') as CanvasRenderingContext2D | OffscreenCanvasRenderingContext2D
   }
 
   get width() {

--- a/packages/client/src/components/pages/game/scripts/const/index.ts
+++ b/packages/client/src/components/pages/game/scripts/const/index.ts
@@ -23,7 +23,7 @@ export const SPRITE_TEXTURE_SIZE = 128 // Размер текстуры в сп�
 export const BG_COLOR = '#11264D'
 export const TEXT_COLOR = '#FFFFFF'
 export const FONT_SIZE = 28
-export const FONT_FAMILY = 'Press Start 2P'
+export const FONT_FAMILY = 'PressStart2P'
 
 export const LIVES_INITIAL = 3
 export const SCORE_INITIAL = 0

--- a/packages/client/src/components/pages/game/scripts/index.ts
+++ b/packages/client/src/components/pages/game/scripts/index.ts
@@ -18,14 +18,11 @@ const onLoad = async () => {
 }
 
 // Без этого метода на канвасе не хочет рендериться кастомный шрифт
-const loadFont = async () => {
-  const font = new FontFace('Press Start 2P', `url(${FONT_PATH})`)
-
-  // @FIXME Разобраться, почему здесь орет Firefox
-  await font.load()
-
+const loadFont = () => new Promise((resolve) => {
+  const font = new FontFace('PressStart2P', `url(${FONT_PATH})`)
   document.fonts.add(font)
-}
+  font.load().then(resolve)
+})
 
 const loadResources = async () => {
   await loadFont()


### PR DESCRIPTION
1. У браузеров и канваса свои заморочки насчет `new FontFace`, вроде помогает сделать имя шрифта состоящим из одного слова
2. Немного переделал сам метод `loadFont`, чтобы не ругались основные браузеры
3. Использовать полноценный полифил для работы с воркерами нам не очень нужно (игра не блокирует настолько основной поток), поэтому просто используем обычный канвас, если `OffscreenCanvas` недоступен