### PR TITLE
[81] Fullscreen API, Game page navbar, Show final score

### DIFF
--- a/packages/client/src/components/pages/end-game/EndGame.tsx
+++ b/packages/client/src/components/pages/end-game/EndGame.tsx
@@ -15,12 +15,11 @@ const EndGame = () => {
 
   const { score } = useSelector(state => state.other)
 
-  // временно, чтобы можно было посмотреть
-  // useEffect(() => {
-  //   if (state !== 'game') {
-  //     navigate(routes.main.path, {replace: true})
-  //   }
-  // }, [])
+  useEffect(() => {
+    if (state !== 'game') {
+      navigate(routes.main.path, {replace: true})
+    }
+  }, [])
 
   return (
     <Stack

--- a/packages/client/src/components/pages/end-game/EndGame.tsx
+++ b/packages/client/src/components/pages/end-game/EndGame.tsx
@@ -4,6 +4,7 @@ import { Stack, Typography } from '@mui/material'
 import { routes } from '@organisms/app-routes'
 import { MainMenuItem } from '@atoms/main-menu-item'
 import { useLocation, useNavigate } from 'react-router-dom'
+import { useSelector } from '@utils/hooks'
 
 const menuItems = [routes.game, routes.main];
 
@@ -11,6 +12,8 @@ const EndGame = () => {
   const location = useLocation()
   const navigate = useNavigate()
   const state = location.state
+
+  const { score } = useSelector(state => state.other)
 
   // временно, чтобы можно было посмотреть
   // useEffect(() => {
@@ -27,7 +30,7 @@ const EndGame = () => {
     >
       <Stack alignItems="center" spacing={2}>
         <Typography variant="subtitle1" fontSize="140px" lineHeight="140px" sx={{':hover': {textDecoration: 'none'}}}>
-          12456
+          { score ?? 0 }
         </Typography>
         <Typography variant="subtitle1" fontSize="32px" sx={{':hover': {textDecoration: 'none'}}}>
           Игра окончена

--- a/packages/client/src/components/pages/game/Game.tsx
+++ b/packages/client/src/components/pages/game/Game.tsx
@@ -1,3 +1,4 @@
+import { withNavbar } from '@services/withNavbar'
 import { useEffect } from 'react'
 import { Box } from '@mui/material'
 import { routes } from '@organisms/app-routes'
@@ -27,34 +28,29 @@ const Game = () => {
   }, [])
 
   return (
-    <Box sx={{ height: '100vh' }}>
-      <Box
-        sx={{
-          position: 'relative',
-          width: 'min(100vw, calc(100vh * 4 / 3))',
-          aspectRatio: '4 / 3',
-          margin: '0 auto',
-        }}
-      >
-        {Object.values(CanvasSelectors).map((canvasSelector) =>
-          <canvas
-            key={canvasSelector}
-            id={canvasSelector.slice(1)}
-            className={canvasSelector.slice(1)}
-            width="1200"
-            height="900"
-            style={{
-              position: 'absolute',
-              top: 0,
-              left: 0,
-              width: '100%',
-              height: '100%',
-            }}
-          ></canvas>
-        )}
-      </Box>
+    <Box
+      className="game__content"
+      sx={{ flex: 1, position: 'relative', background: 'inherit' }}
+    >
+      {Object.values(CanvasSelectors).map((canvasSelector) =>
+        <canvas
+          key={canvasSelector}
+          id={canvasSelector.slice(1)}
+          className={canvasSelector.slice(1)}
+          width="1200"
+          height="900"
+          style={{
+            position: 'absolute',
+            top: 0,
+            left: 0,
+            width: '100%',
+            height: '100%',
+            objectFit: 'contain',
+          }}
+        ></canvas>
+      )}
     </Box>
   )
 }
 
-export default Game
+export default withNavbar(Game, 'game')

--- a/packages/client/src/components/pages/game/Game.tsx
+++ b/packages/client/src/components/pages/game/Game.tsx
@@ -1,6 +1,6 @@
 import { useEffect } from 'react'
 import { Box } from '@mui/material'
-import { canvasSelectors } from './scripts/const'
+import { CanvasSelectors } from './scripts/const'
 
 const Game = () => {
   useEffect(() => {
@@ -20,7 +20,7 @@ const Game = () => {
           margin: '0 auto',
         }}
       >
-        {Object.values(canvasSelectors).map((canvasSelector) =>
+        {Object.values(CanvasSelectors).map((canvasSelector) =>
           <canvas
             key={canvasSelector}
             id={canvasSelector.slice(1)}

--- a/packages/client/src/components/pages/game/Game.tsx
+++ b/packages/client/src/components/pages/game/Game.tsx
@@ -46,6 +46,7 @@ const Game = () => {
             width: '100%',
             height: '100%',
             objectFit: 'contain',
+            objectPosition: 'top',
           }}
         ></canvas>
       )}

--- a/packages/client/src/components/pages/game/Game.tsx
+++ b/packages/client/src/components/pages/game/Game.tsx
@@ -1,13 +1,29 @@
 import { useEffect } from 'react'
 import { Box } from '@mui/material'
+import { routes } from '@organisms/app-routes'
+import { useNavigate } from 'react-router-dom'
 import { CanvasSelectors } from './scripts/const'
 
 const Game = () => {
+  const navigate = useNavigate()
+
   useEffect(() => {
+    let cleanListeners: null | (() => void) = null;
+
     (async () => {
-      const { loadResources } = await import('./scripts')
+      const { loadResources, registerEndGameCallback, removeListeners } = await import('./scripts')
+
+      cleanListeners = removeListeners
+
+      registerEndGameCallback((score: number) => {
+        // @TODO Здесь нужно положить score в стор
+        navigate(routes.score.path)
+      })
+
       loadResources()
     })()
+
+    return () => cleanListeners?.()
   }, [])
 
   return (

--- a/packages/client/src/components/pages/game/Game.tsx
+++ b/packages/client/src/components/pages/game/Game.tsx
@@ -4,9 +4,12 @@ import { Box } from '@mui/material'
 import { routes } from '@organisms/app-routes'
 import { useNavigate } from 'react-router-dom'
 import { CanvasSelectors } from './scripts/const'
+import { useDispatch } from '@utils/hooks'
+import { updateScore } from '@services/store/actions/other'
 
 const Game = () => {
   const navigate = useNavigate()
+  const dispatch: any = useDispatch()
 
   useEffect(() => {
     let cleanListeners: null | (() => void) = null;
@@ -17,7 +20,7 @@ const Game = () => {
       cleanListeners = removeListeners
 
       registerEndGameCallback((score: number) => {
-        // @TODO Здесь нужно положить score в стор
+        dispatch(updateScore(score))
         navigate(routes.score.path)
       })
 

--- a/packages/client/src/components/pages/game/Game.tsx
+++ b/packages/client/src/components/pages/game/Game.tsx
@@ -21,7 +21,7 @@ const Game = () => {
 
       registerEndGameCallback((score: number) => {
         dispatch(updateScore(score))
-        navigate(routes.score.path)
+        navigate(routes.score.path, { state: 'game' })
       })
 
       loadResources()

--- a/packages/client/src/components/pages/game/scripts/Control/index.ts
+++ b/packages/client/src/components/pages/game/scripts/Control/index.ts
@@ -5,13 +5,13 @@
  * @TODO Вызывать removeListeners при смене роута
  */
 
-import { TCallback } from './types'
+import { TKey, TCallback } from './types'
 
 export class Control {
-  private _key: string
+  private _key: TKey
   private _callback: TCallback
 
-  constructor(key: string, callback: TCallback) {
+  constructor(key: TKey, callback: TCallback) {
     this._key = key
     this._callback = callback
 
@@ -23,10 +23,14 @@ export class Control {
     document.addEventListener('keyup', this._onKeyReleased)
   }
 
+  private _checkForKey(key: string) {
+    return Array.isArray(this._key) ? this._key.includes(key) : this._key === key
+  }
+
   private _onKeyPressed = (evt: KeyboardEvent) => {
     const { code } = evt
 
-    if (code === this._key) {
+    if (this._checkForKey(code)) {
       evt.preventDefault()
       this._callback(true)
     }
@@ -35,7 +39,7 @@ export class Control {
   private _onKeyReleased = (evt: KeyboardEvent) => {
     const { code } = evt
 
-    if (code === this._key) {
+    if (this._checkForKey(code)) {
       evt.preventDefault()
       this._callback(false)
     }

--- a/packages/client/src/components/pages/game/scripts/Control/index.ts
+++ b/packages/client/src/components/pages/game/scripts/Control/index.ts
@@ -24,18 +24,18 @@ export class Control {
   }
 
   private _onKeyPressed = (evt: KeyboardEvent) => {
-    const { key } = evt
+    const { code } = evt
 
-    if (key === this._key) {
+    if (code === this._key) {
       evt.preventDefault()
       this._callback(true)
     }
   }
 
   private _onKeyReleased = (evt: KeyboardEvent) => {
-    const { key } = evt
+    const { code } = evt
 
-    if (key === this._key) {
+    if (code === this._key) {
       evt.preventDefault()
       this._callback(false)
     }

--- a/packages/client/src/components/pages/game/scripts/Control/types.ts
+++ b/packages/client/src/components/pages/game/scripts/Control/types.ts
@@ -1,1 +1,3 @@
+export type TKey = string | string[]
+
 export type TCallback = (isPressed: boolean) => unknown

--- a/packages/client/src/components/pages/game/scripts/canvas/index.ts
+++ b/packages/client/src/components/pages/game/scripts/canvas/index.ts
@@ -126,9 +126,15 @@ class Canvas {
   }
 }
 
-const canvasStatic = new Canvas(CanvasSelectors.Static)
-const canvasDynamic = new Canvas(CanvasSelectors.Dynamic, true)
-const canvasModal = new Canvas(CanvasSelectors.Modal, true)
+let canvasStatic: Canvas
+let canvasDynamic: Canvas
+let canvasModal: Canvas
+
+const updateCanvases = () => {
+  canvasStatic = new Canvas(CanvasSelectors.Static)
+  canvasDynamic = new Canvas(CanvasSelectors.Dynamic, true)
+  canvasModal = new Canvas(CanvasSelectors.Modal, true)
+}
 
 // Экспортируем динамический канвас как canvas, чтобы не писать везде canvasDynamic
-export { canvasStatic, canvasDynamic as canvas, canvasModal }
+export { canvasStatic, canvasDynamic as canvas, canvasModal, updateCanvases }

--- a/packages/client/src/components/pages/game/scripts/canvas/index.ts
+++ b/packages/client/src/components/pages/game/scripts/canvas/index.ts
@@ -1,5 +1,5 @@
 import {
-  canvasSelectors,
+  CanvasSelectors,
   TILE_SIZE,
   SPRITE_TEXTURE_SIZE,
   FONT_FAMILY,
@@ -19,7 +19,7 @@ class Canvas {
   private _offscreenContext: CanvasRenderingContext2D | OffscreenCanvasRenderingContext2D
 
   // Альфа-канал не нужен для статического канваса, экономим ресурсы
-  constructor(selector: canvasSelectors, alpha = false) {
+  constructor(selector: CanvasSelectors, alpha = false) {
     const canvasEl = document.querySelector(selector)
 
     if (!canvasEl) {
@@ -126,9 +126,9 @@ class Canvas {
   }
 }
 
-const canvasStatic = new Canvas(canvasSelectors.static)
-const canvasDynamic = new Canvas(canvasSelectors.dynamic, true)
-const canvasModal = new Canvas(canvasSelectors.modal, true)
+const canvasStatic = new Canvas(CanvasSelectors.Static)
+const canvasDynamic = new Canvas(CanvasSelectors.Dynamic, true)
+const canvasModal = new Canvas(CanvasSelectors.Modal, true)
 
 // Экспортируем динамический канвас как canvas, чтобы не писать везде canvasDynamic
 export { canvasStatic, canvasDynamic as canvas, canvasModal }

--- a/packages/client/src/components/pages/game/scripts/const/index.ts
+++ b/packages/client/src/components/pages/game/scripts/const/index.ts
@@ -1,9 +1,9 @@
 import { TTextures } from './types'
 
-export enum canvasSelectors {
-  static = '#game_static',
-  dynamic = '#game_dynamic',
-  modal = '#game_modal',
+export enum CanvasSelectors {
+  Static = '#game_static',
+  Dynamic = '#game_dynamic',
+  Modal = '#game_modal',
 }
 
 /**

--- a/packages/client/src/components/pages/game/scripts/const/index.ts
+++ b/packages/client/src/components/pages/game/scripts/const/index.ts
@@ -27,7 +27,7 @@ export const TEXT_COLOR_ERROR = '#FF3232'
 export const FONT_SIZE = 28
 export const FONT_FAMILY = 'PressStart2P'
 
-export const LIVES_INITIAL = 3
+export const LIVES_INITIAL = 2
 export const SCORE_INITIAL = 0
 export const TIME_INITIAL_S = 300
 

--- a/packages/client/src/components/pages/game/scripts/hero/index.ts
+++ b/packages/client/src/components/pages/game/scripts/hero/index.ts
@@ -50,7 +50,7 @@ const KEY_LEFT = 'ArrowLeft'
 const KEY_RIGHT = 'ArrowRight'
 const KEY_UP = 'ArrowUp'
 const KEY_DOWN = 'ArrowDown'
-const KEY_BOMB_PLACE = ' '
+const KEY_BOMB_PLACE = 'Space'
 const KEY_BOMB_DETONATE = 'Control'
 
 const SPEED_DEFAULT = 3 // Скорость героя по умолчанию

--- a/packages/client/src/components/pages/game/scripts/index.ts
+++ b/packages/client/src/components/pages/game/scripts/index.ts
@@ -1,9 +1,16 @@
 import { loadSprite } from './images'
+import { updateCanvases } from './canvas'
 import { level } from './level'
+import { hero } from './hero'
+
+type RedirectFunction = (score: number) => void
 
 const FONT_PATH = '/src/assets/fonts/PressStart2P.ttf'
 
+export let endGameCallback: null | RedirectFunction = null
+
 const onLoad = async () => {
+  updateCanvases()
   level.startGame()
 }
 
@@ -19,5 +26,14 @@ const loadResources = async () => {
   loadSprite()
 }
 
+const registerEndGameCallback = (func: RedirectFunction) => {
+  endGameCallback = func
+}
+
+const removeListeners = () => {
+  level.removeControl()
+  hero.removeControl()
+}
+
 // onLoad вызовет загрузчик изображений, когда сделает свое дело
-export { loadResources, onLoad }
+export { loadResources, onLoad, registerEndGameCallback, removeListeners }

--- a/packages/client/src/components/pages/game/scripts/level/index.ts
+++ b/packages/client/src/components/pages/game/scripts/level/index.ts
@@ -42,7 +42,7 @@ const SAFE_TILES_WALL_COUNT = 2 // Нам не нужно, чтобы стена
 const SAFE_TILES_ENEMY_COUNT = 5 // И враги тоже
 const WALL_PROBABILITY_PCT = 40 // Вероятность появления стены
 const LEVEL_COMPLETE_SCORE_BASE = 1000
-const KEY_PAUSE = 'Escape'
+const KEYS_PAUSE = ['Escape', 'KeyP']
 const KEY_FULLSCREEN = 'KeyF'
 const GAME_CONTENT_ELEMENT_SELECTOR = '.game__content'
 
@@ -68,7 +68,7 @@ class Level {
 
   constructor() {
     this._controlFullscreen = new Control(KEY_FULLSCREEN, this._toggleFullscreen)
-    this._controlPause = new Control(KEY_PAUSE, this._togglePause)
+    this._controlPause = new Control(KEYS_PAUSE, this._togglePause)
   }
 
   private _showIntro() {

--- a/packages/client/src/components/pages/game/scripts/level/index.ts
+++ b/packages/client/src/components/pages/game/scripts/level/index.ts
@@ -44,6 +44,7 @@ const WALL_PROBABILITY_PCT = 40 // Вероятность появления с�
 const LEVEL_COMPLETE_SCORE_BASE = 1000
 const KEY_PAUSE = 'Escape'
 const KEY_FULLSCREEN = 'KeyF'
+const GAME_CONTENT_ELEMENT_SELECTOR = '.game__content'
 
 class Level {
   private _controlFullscreen: null | Control = null
@@ -307,10 +308,12 @@ class Level {
       return
     }
 
+    const element = document.querySelector(GAME_CONTENT_ELEMENT_SELECTOR)
+
     if (document.fullscreenElement) {
       document.exitFullscreen()
     } else {
-      document.documentElement.requestFullscreen()
+      element?.requestFullscreen()
     }
   }
 

--- a/packages/client/src/components/pages/game/scripts/level/index.ts
+++ b/packages/client/src/components/pages/game/scripts/level/index.ts
@@ -41,6 +41,7 @@ const SAFE_TILES_ENEMY_COUNT = 5 // И враги тоже
 const WALL_PROBABILITY_PCT = 40 // Вероятность появления стены
 const LEVEL_COMPLETE_SCORE_BASE = 1000
 const KEY_PAUSE = 'Escape'
+const KEY_FULLSCREEN = 'KeyF'
 
 class Level {
   private _field: TField = []
@@ -61,7 +62,8 @@ class Level {
   scorePopups: Record<number, Score> = {}
 
   constructor() {
-    new Control(KEY_PAUSE, this.togglePause)
+    new Control(KEY_FULLSCREEN, this._toggleFullscreen)
+    new Control(KEY_PAUSE, this._togglePause)
   }
 
   private _showIntro() {
@@ -278,6 +280,33 @@ class Level {
     canvasModal.update()
   }
 
+  private _togglePause = (isKeydown: boolean) => {
+    if (!isKeydown || !this._isPauseAllowed) {
+      return
+    }
+
+    this._isPaused = !this._isPaused
+
+    if (this._isPaused) {
+      pause.show()
+    } else {
+      pause.hide()
+      this._clearCanvasModal()
+    }
+  }
+
+  private _toggleFullscreen = (isKeydown: boolean) => {
+    if (!isKeydown) {
+      return
+    }
+
+    if (document.fullscreenElement) {
+      document.exitFullscreen()
+    } else {
+      document.documentElement.requestFullscreen()
+    }
+  }
+
   startGame() {
     this.goToNextLevel(1)
   }
@@ -318,21 +347,6 @@ class Level {
     const isInnerRow = row >= 0 && row < MAP_TILES_COUNT_Y - 2
 
     return isInnerCol && isInnerRow ? this._field[row][col] : TEXTURE_COLUMN
-  }
-
-  togglePause = (isKeydown: boolean) => {
-    if (!isKeydown || !this._isPauseAllowed) {
-      return
-    }
-
-    this._isPaused = !this._isPaused
-
-    if (this._isPaused) {
-      pause.show()
-    } else {
-      pause.hide()
-      this._clearCanvasModal()
-    }
   }
 
   updateTexture(texture: number, col: number, row: number) {

--- a/packages/client/src/components/pages/game/scripts/stats/index.ts
+++ b/packages/client/src/components/pages/game/scripts/stats/index.ts
@@ -62,6 +62,7 @@ class Stats {
   reset() {
     this._score = SCORE_INITIAL
     this._time = TIME_INITIAL_S
+    this.lives = LIVES_INITIAL
   }
 
   addScore(score: number) {

--- a/packages/client/src/components/pages/game/scripts/stats/index.ts
+++ b/packages/client/src/components/pages/game/scripts/stats/index.ts
@@ -16,13 +16,14 @@ import { level } from '../level'
 import { panel } from '../panel'
 
 class Stats {
-  private _score = SCORE_INITIAL
-  private _time = TIME_INITIAL_S
+  private _score: number = SCORE_INITIAL
+  private _time: number = TIME_INITIAL_S
   private _timeInterval: null | PausableInterval = null
 
   lives = LIVES_INITIAL
 
   constructor() {
+    this.reset()
     this._resetInterval()
   }
 
@@ -52,6 +53,15 @@ class Stats {
 
   get timeLeft() {
     return this._time
+  }
+
+  get score() {
+    return this._score
+  }
+
+  reset() {
+    this._score = SCORE_INITIAL
+    this._time = TIME_INITIAL_S
   }
 
   addScore(score: number) {

--- a/packages/client/src/services/store/actions/other.ts
+++ b/packages/client/src/services/store/actions/other.ts
@@ -1,0 +1,19 @@
+import { AppDispatch, AppThunk } from '@src/types/store'
+
+export const SCORE_UPDATE = 'SCORE_UPDATE'
+
+interface IUpdateScore {
+  readonly type: typeof SCORE_UPDATE
+  readonly payload: number
+}
+
+export type TOtherActions = IUpdateScore
+
+export const updateScore: AppThunk = (score: number) => {
+  return function(dispatch: AppDispatch) {
+    dispatch({
+      type: SCORE_UPDATE,
+      payload: score,
+    })
+  }
+}

--- a/packages/client/src/services/store/reducers/index.ts
+++ b/packages/client/src/services/store/reducers/index.ts
@@ -1,8 +1,10 @@
 import { combineReducers } from 'redux'
 import { userRegistrationReducer } from '@services/store/reducers/user-registration'
 import { userAuthReducer } from '@services/store/reducers/user-auth'
+import { otherReducer } from '@services/store/reducers/other'
 
 export const rootReducer = combineReducers({
   userRegistration: userRegistrationReducer,
   userAuth: userAuthReducer,
+  other: otherReducer,
 })

--- a/packages/client/src/services/store/reducers/other.ts
+++ b/packages/client/src/services/store/reducers/other.ts
@@ -1,0 +1,23 @@
+import { TOtherActions } from '@services/store/actions/other'
+
+export interface IOtherState {
+  score: null | number
+}
+
+const initialState: IOtherState = {
+  score: null
+}
+
+export const otherReducer = (state = initialState, action: TOtherActions) => {
+  switch (action.type) {
+    case 'SCORE_UPDATE': {
+      return {
+        ...state,
+        score: action.payload,
+      }
+    }
+    default: {
+      return state
+    }
+  }
+}

--- a/packages/client/src/services/withNavbar/withNavbar.tsx
+++ b/packages/client/src/services/withNavbar/withNavbar.tsx
@@ -40,6 +40,11 @@ const configOptions: configOptions = {
     links: ['forum'],
     protectedRoute: true,
   },
+  game: {
+    showLogo: true,
+    links: ['profile', 'forum', 'leaderboard'],
+    protectedRoute: true,
+  },
   score: {
     showLogo: true,
     links: ['profile', 'leaderboard', 'forum'],


### PR DESCRIPTION
1. В конце игры переходим на роут `/score` и отображаем набранные очки
1. При уходе со страницы игры очищаем слушатели
1. Фикс для канвасов, чтобы при смене роутов игра корректно запускалась
1. Добавляем навбар на страницу с игрой
1. Добавляем Fullscreen API для игры при нажатии на `F`. В отличие от стандартного фулскрина, в полноэкранный режим переходит не вся страница с навбаром, а только основной контейнер
1. Паузу можно ставить нажатием на `P` (пришлось чуть переделать класс `Control`)
1. Меняем количество жизней на 2 (чтобы всего было три)
1. Чутка рефакторинга